### PR TITLE
Publicize `StrokeThicknessProperty` to prevent access exceptions.

### DIFF
--- a/LucideAvalonia/Lucide.axaml.cs
+++ b/LucideAvalonia/Lucide.axaml.cs
@@ -59,7 +59,7 @@ public partial class Lucide : UserControl
     }
 
     // Define a dependency property for the stroke thickness
-    private static readonly StyledProperty<double> StrokeThicknessProperty =
+    public static readonly StyledProperty<double> StrokeThicknessProperty =
         AvaloniaProperty.Register<Lucide, double>("StrokeThickness");
 
     // Property to get or set the stroke thickness

--- a/LucideAvalonia/LucideAvalonia.csproj
+++ b/LucideAvalonia/LucideAvalonia.csproj
@@ -18,7 +18,7 @@
     <RepositoryUrl>https://github.com/MarwanFr/LucideAvaloniaUI/</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>LucideAvalonia</PackageId>
-    <Version>1.6.1</Version>
+    <Version>1.6.2</Version>
     <PackageTags>avalonia;icons;icon;ui;lucide;avaloniaui</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #3.