### PR TITLE
Support for Avalonia v12

### DIFF
--- a/LucideAvalonia/LucideAvalonia.csproj
+++ b/LucideAvalonia/LucideAvalonia.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.1.0-beta1" />
+    <PackageReference Include="Avalonia" Version="12.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This library is ideal for:
 ### Installation
 
 > [!WARNING]
-> This library is compatible only with AvaloniaUI version 11.1.0-beta1 or higher. It does not support earlier versions.
+> This library is compatible with AvaloniaUI version 12.0.0 or higher. For AvaloniaUI 11.x, use LucideAvalonia version 1.6.2 or earlier.
 
 To install the library, you can use NuGet with the following command:
 

--- a/TestApp/TestApp.csproj
+++ b/TestApp/TestApp.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="11.1.0-beta1" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.0-beta1" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.0" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Using LucideAvaloniaUI 1.6.2 in an Avalonia 12.0.0+ application results in a runtime exception:
```
Unhandled exception. System.MissingMethodException: Method not found: 'Void Avalonia.Markup.Xaml.MarkupExtensions.RelativeSourceExtension..ctor(Avalonia.Data.RelativeSourceMode)'.
   at LucideAvalonia.Lucide.!XamlIlPopulate(IServiceProvider, Lucide)
   at LucideAvalonia.Lucide.!XamlIlPopulate(IServiceProvider, Lucide)
   at LucideAvalonia.Lucide.!XamlIlPopulateTrampoline(Lucide)
   at LucideAvalonia.Lucide.InitializeComponent()
   at LucideAvalonia.Lucide..ctor()
   at DragonFruit.OnionFruit.Views.MainWindow.XamlClosure_2.Build_1(IServiceProvider) in R:\onionfruit\DragonFruit.OnionFruit\Views/MainWindow.axaml:line 83
```

Line 83 is a `Lucide` component:

```xml
<lucideAvalonia:Lucide Icon="LoaderPinwheel" StrokeBrush="White" StrokeThickness="2" Width="16" Height="16" />
```

The simplest fix is to bump Avalonia to v12 which corrects the bindings (what this PR currently does). If backwards compatibility is preferred, the binding could be done in code-behind.